### PR TITLE
Fix JDSP4Linux on other than English languages

### DIFF
--- a/jdsp
+++ b/jdsp
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 #Noah Bliss
 
+# Workaround to fix JDSP4Linux on other than
+# English languages
+# ------------------------------------------
+# GST cannot find entry 'device' on other
+# than English languages
+
+export LC_ALL=C
+
 # quick mod of this script to test my jdsp plugin
 # if someone reads this: feel free to send a PR with an optimized script for jdsp4linux (+compatibility for V4L)
 # ~thepbone


### PR DESCRIPTION
GST cannot find entry 'device' on Russian language
On Russian language it should use russian translation
for word 'device'. So just use English for every program
executed by JDSP.