### PR TITLE
src.pro: added PREFIX config var

### DIFF
--- a/libjamesdsp/libjamesdsp.pro
+++ b/libjamesdsp/libjamesdsp.pro
@@ -101,7 +101,12 @@ SOURCES += \
     JdspImpResToolbox.c
 
 unix {
-    target.path = /usr/lib
+    isEmpty(LIBDIR) {
+        LIBDIR = lib
+    }
+
+    LIBDIR = $$absolute_path($$LIBDIR, $$PREFIX)
+    target.path = $$LIBDIR
 }
 else: error("Static linking only available on Linux systems")
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -173,9 +173,17 @@ RESOURCES += \
     ../resources/resources.qrc
 
 # Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/bin/
+isEmpty(PREFIX){
+    qnx: PREFIX = /tmp/$${TARGET}
+    else: unix:!android: PREFIX = /usr
+}
 
+isEmpty(BINDIR) {
+    BINDIR = bin
+}
+
+BINDIR = $$absolute_path($$BINDIR, $$PREFIX)
+target.path = $$BINDIR
 !isEmpty(target.path): INSTALLS += target
 
 unix {


### PR DESCRIPTION
The .pro files assume that files will be copied to the `/usr` prefix.
This is not a correct assumprtion to make and on NixOS we have to add [this patch](https://github.com/NixOS/nixpkgs/blob/fef0b20c8d5fbf14ed2ad7f2ff2bfc29633a0a62/pkgs/applications/audio/jamesdsp/0002-src.pro-added-PREFIX-config-var.patch) to build the project, as discovered in this [pr](https://github.com/NixOS/nixpkgs/pull/154158).
 This pr simply upstream the patch.