### PR TITLE
PPA adding fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,11 @@ If you don't know which version fits your Linux setup, go to the [PipeWire vs Pu
 Add PPA Repo
 ```bash
 sudo apt install -y curl
+# TheBone’s PPA Repository
 curl -s --compressed "https://thepbone.github.io/PPA-Repository/KEY.gpg" -o thepbone_ppa.gpg
-cat thepbone_ppa.gpg | sudo tee -a /usr/share/keyrings/thepbone_ppa.gpg > /dev/null
-sudo curl -s --compressed -o /etc/apt/sources.list.d/thepbone_ppa.list "https://thepbone.github.io/PPA-Repository/thepbone_ppa.list"
-sudo apt update
+
+cat thepbone_ppa.gpg | sudo gpg --dearmour -o /etc/apt/trusted.gpg.d/thepbone_ppa.gpg
+echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/thepbone_ppa.gpg] https://thepbone.github.io/PPA-Repository ./" > /etc/apt/sources.list.d/thepbone_ppa.list
 ```
 Install from PPA
 

--- a/README.md
+++ b/README.md
@@ -142,11 +142,12 @@ If you don't know which version fits your Linux setup, go to the [PipeWire vs Pu
 Add PPA Repo
 ```bash
 sudo apt install -y curl
-# TheBone’s PPA Repository
+# TheBone’s PPA Repository key
 curl -s --compressed "https://thepbone.github.io/PPA-Repository/KEY.gpg" -o thepbone_ppa.gpg
 
 cat thepbone_ppa.gpg | sudo gpg --dearmour -o /etc/apt/trusted.gpg.d/thepbone_ppa.gpg
 echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/thepbone_ppa.gpg] https://thepbone.github.io/PPA-Repository ./" > /etc/apt/sources.list.d/thepbone_ppa.list
+sudo apt update
 ```
 Install from PPA
 


### PR DESCRIPTION
Previous variant was not working correct on Ubuntu 22.04:
```
...
W: https://thepbone.github.io/PPA-Repository/./InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
...
```