### PR TITLE
fixed icons on HighDPI screens

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -276,17 +276,17 @@ MainWindow::MainWindow(bool     statupInTray,
         connect(_styleHelper, &StyleHelper::iconColorChanged, this, [this](bool white){
             if (white)
             {
-                ui->set->setIcon(QPixmap(":/icons/settings-white.svg"));
-                ui->cpreset->setIcon(QPixmap(":/icons/queue-white.svg"));
-                ui->toolButton->setIcon(QPixmap(":/icons/menu-white.svg"));
-                ui->disableFX->setIcon(QPixmap(":/icons/power-white.svg"));
+                ui->set->setIcon(QIcon(":/icons/settings-white.svg"));
+                ui->cpreset->setIcon(QIcon(":/icons/queue-white.svg"));
+                ui->toolButton->setIcon(QIcon(":/icons/menu-white.svg"));
+                ui->disableFX->setIcon(QIcon(":/icons/power-white.svg"));
             }
             else
             {
-                ui->set->setIcon(QPixmap(":/icons/settings.svg"));
-                ui->cpreset->setIcon(QPixmap(":/icons/queue.svg"));
-                ui->toolButton->setIcon(QPixmap(":/icons/menu.svg"));
-                ui->disableFX->setIcon(QPixmap(":/icons/power.svg"));
+                ui->set->setIcon(QIcon(":/icons/settings.svg"));
+                ui->cpreset->setIcon(QIcon(":/icons/queue.svg"));
+                ui->toolButton->setIcon(QIcon(":/icons/menu.svg"));
+                ui->disableFX->setIcon(QIcon(":/icons/power.svg"));
             }
         });
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,6 +77,7 @@ int main(int   argc,
 #endif
 
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps, true);
     QApplication app(argc, argv);
 
 	QCommandLineParser parser;


### PR DESCRIPTION
**before** (icons on buttons are blurred, especially noticeable on "settings" icon):
![Screenshot_20230221_083327](https://user-images.githubusercontent.com/947647/220355197-eb9e4549-1955-4e9f-af7d-ce21c35ce400.png)

**after** (icons on buttons are clear, especially noticeable on "settings" icon):
![Screenshot_20230221_083250](https://user-images.githubusercontent.com/947647/220355227-3c891901-d941-4b34-899b-3f423e08de54.png)
