### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Package maintained by [@theAeon](https://github.com/theAeon) on [Fedora COPR](ht
 Built for Fedora 34/35/Rawhide and OpenSUSE Tumbleweed.
 
 ```
-yum copr enable arrobbins/JDSP4Linux && yum update && yum install jamesdsp
+yum copr enable arrobbins/JDSP4Linux && yum update && yum install JamesDSP
 ```
 
 If you are still using PulseAudio with your Fedora/openSUSE installation, refer to the '[Build from sources](#build-from-sources)' section below instead.


### PR DESCRIPTION
Add uppercase characters for Fedora package name - The package name has uppercase characters and cannot be found using DNF without the correct case.