### PR TITLE
Update AeqPackageManager.cpp to fix the AutoEQ link

### DIFF
--- a/src/subprojects/AutoEqIntegration/AeqPackageManager.cpp
+++ b/src/subprojects/AutoEqIntegration/AeqPackageManager.cpp
@@ -8,7 +8,7 @@
 #include <QFile>
 #include <QNetworkAccessManager>
 
-#define REPO_ROOT QString("https://raw.githubusercontent.com/ThePBone/AutoEqPackages/main/")
+#define REPO_ROOT QString("https://raw.githubusercontent.com/ThePBone/AutoEqPackages/main")
 
 AeqPackageManager::AeqPackageManager(QObject *parent) : QObject(parent), nam(new QNetworkAccessManager(this))
 {


### PR DESCRIPTION
Update AeqPackageManager.cpp to fix the AutoEQ link as there is an erroneous trailing slash