### PR TITLE
feat(presets): add per-preset output device association

### DIFF
--- a/src/data/PresetManager.cpp
+++ b/src/data/PresetManager.cpp
@@ -5,6 +5,7 @@
 #include "model/PresetListModel.h"
 
 #include <QFile>
+#include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonObject>
@@ -12,6 +13,7 @@
 PresetManager::PresetManager() : _presetModel(new PresetListModel(this))
 {
     loadRules();
+    loadPresetDevices();
 }
 
 bool PresetManager::exists(const QString &name) const
@@ -38,6 +40,11 @@ bool PresetManager::loadFromPath(const QString &filename)
 
     QFile::copy(src, dest);
     DspConfig::instance().load();
+
+    // If this preset remembers an output device, switch to it. The preset name is
+    // the file's base name; presets without an association leave the device untouched.
+    applyPresetDevice(QFileInfo(filename).completeBaseName());
+
     Log::debug("Loaded " + filename);
     return true;
 }
@@ -55,6 +62,14 @@ void PresetManager::rename(const QString &name, const QString &newName)
     {
         QFile::rename(path, QDir(path).filePath(newName + ".conf"));
     }
+
+    // Keep the device association in sync with the preset's new name
+    if (_presetDevices.contains(name))
+    {
+        _presetDevices[newName] = _presetDevices.take(name);
+        savePresetDevices();
+    }
+
     this->_presetModel->rescan();
 }
 
@@ -64,6 +79,7 @@ bool PresetManager::remove(const QString &name)
     if (QFile::exists(path))
     {
         QFile::remove(path);
+        clearPresetDevice(name);
         this->_presetModel->rescan();
         return true;
     }
@@ -96,7 +112,11 @@ void PresetManager::onOutputDeviceChanged(const QString &deviceName, const QStri
 {
     QString defaultRouteId = QString::fromStdString(RouteListModel::makeDefaultRoute().name);
     auto executeRule = [this, deviceName, outputRouteId, defaultRouteId](const PresetRule& rule){
+        // A rule loads a preset *because* the device changed; do not let the loaded
+        // preset re-apply a device, which would feed back into this handler.
+        _suppressDeviceApply = true;
         loadFromPath(AppConfig::instance().getPath("presets/" + rule.preset + ".conf"));
+        _suppressDeviceApply = false;
         emit presetAutoloaded(deviceName, rule.routeName, rule.routeId == defaultRouteId);
     };
 
@@ -201,5 +221,88 @@ void PresetManager::removeRule(const QString &deviceId, const QString &routeId)
 QVector<PresetRule> PresetManager::rules() const
 {
     return _rules;
+}
+
+QString PresetManager::presetDevicesPath() const
+{
+    return AppConfig::instance().getPath("preset_devices.json");
+}
+
+void PresetManager::loadPresetDevices()
+{
+    _presetDevices.clear();
+
+    QFile json(presetDevicesPath());
+    if(!json.exists())
+    {
+        return;
+    }
+
+    json.open(QFile::ReadOnly);
+    QJsonObject root = QJsonDocument::fromJson(json.readAll()).object();
+    json.close();
+
+    for(auto it = root.constBegin(); it != root.constEnd(); ++it)
+    {
+        _presetDevices.insert(it.key(), it.value().toObject());
+    }
+}
+
+void PresetManager::savePresetDevices()
+{
+    QFile json(presetDevicesPath());
+    if(!json.open(QIODevice::WriteOnly)){
+        Log::error("PresetManager::savePresetDevices: Cannot open json file");
+        return;
+    }
+
+    QJsonObject root;
+    for(auto it = _presetDevices.constBegin(); it != _presetDevices.constEnd(); ++it)
+    {
+        root.insert(it.key(), it.value());
+    }
+
+    json.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+    json.close();
+}
+
+bool PresetManager::hasPresetDevice(const QString &name) const
+{
+    return _presetDevices.contains(name);
+}
+
+void PresetManager::setPresetDevice(const QString &name)
+{
+    QJsonObject entry;
+    entry["deviceId"]   = AppConfig::instance().get<QString>(AppConfig::AudioOutputDevice);
+    entry["useDefault"] = AppConfig::instance().get<bool>(AppConfig::AudioOutputUseDefault);
+    _presetDevices[name] = entry;
+    savePresetDevices();
+}
+
+void PresetManager::clearPresetDevice(const QString &name)
+{
+    if(_presetDevices.remove(name) > 0)
+    {
+        savePresetDevices();
+    }
+}
+
+void PresetManager::applyPresetDevice(const QString &name)
+{
+    if(_suppressDeviceApply || !_presetDevices.contains(name))
+    {
+        return;
+    }
+
+    const QJsonObject entry = _presetDevices.value(name);
+
+    // Mirror SettingsFragment: setting these AppConfig keys triggers a live device
+    // switch via PipewireAudioService::onAppConfigUpdated.
+    AppConfig::instance().set(AppConfig::AudioOutputUseDefault, entry["useDefault"].toBool());
+    if(!entry["useDefault"].toBool())
+    {
+        AppConfig::instance().set(AppConfig::AudioOutputDevice, entry["deviceId"].toString());
+    }
 }
 

--- a/src/data/PresetManager.cpp
+++ b/src/data/PresetManager.cpp
@@ -41,9 +41,15 @@ bool PresetManager::loadFromPath(const QString &filename)
     QFile::copy(src, dest);
     DspConfig::instance().load();
 
-    // If this preset remembers an output device, switch to it. The preset name is
-    // the file's base name; presets without an association leave the device untouched.
-    applyPresetDevice(QFileInfo(filename).completeBaseName());
+    // If this preset remembers an output device, switch to it. Associations belong to
+    // managed presets only (those in the presets directory), keyed by file base name.
+    // An external file imported via loadExternalFile() must not switch the device just
+    // because its base name happens to collide with a saved preset.
+    if (QFileInfo(filename).dir().absolutePath() ==
+        QDir(AppConfig::instance().getPath("presets/")).absolutePath())
+    {
+        applyPresetDevice(QFileInfo(filename).completeBaseName());
+    }
 
     Log::debug("Loaded " + filename);
     return true;

--- a/src/data/PresetManager.h
+++ b/src/data/PresetManager.h
@@ -3,6 +3,8 @@
 
 #include "PresetRule.h"
 
+#include <QJsonObject>
+#include <QMap>
 #include <QObject>
 #include <QVector>
 
@@ -29,6 +31,13 @@ public:
     bool addRule(const PresetRule& rule);
     void removeRule(const QString &deviceId, const QString &routeId);
 
+    // Per-preset output device association (PipeWire only).
+    // Lets a preset optionally remember an output device and switch to it on load.
+    bool hasPresetDevice(const QString& name) const;
+    void setPresetDevice(const QString& name);
+    void clearPresetDevice(const QString& name);
+    void applyPresetDevice(const QString& name);
+
     PresetListModel *presetModel() const;
 
 signals:
@@ -49,9 +58,16 @@ public slots:
     void saveRules() const;
 private:
     QVector<PresetRule> _rules;
+    QMap<QString, QJsonObject> _presetDevices;
     PresetListModel* _presetModel;
+    // Suppresses applyPresetDevice() while a preset is being auto-loaded by a
+    // device->preset rule, to avoid a device-change feedback loop.
+    bool _suppressDeviceApply = false;
 
     QString rulesPath() const;
+    QString presetDevicesPath() const;
+    void loadPresetDevices();
+    void savePresetDevices();
 };
 
 #endif // PRESETMANAGER_H

--- a/src/interface/fragment/PresetFragment.cpp
+++ b/src/interface/fragment/PresetFragment.cpp
@@ -27,7 +27,9 @@ PresetFragment::PresetFragment(IAudioService* service, QWidget *parent) :
     ui->load->setEnabled(false);
 
 #ifdef USE_PULSEAUDIO
+    // Device switching is only implemented for the PipeWire backend
     ui->rules->setVisible(false);
+    ui->rememberDevice->setVisible(false);
 #endif
 
     connect(ui->add, &QPushButton::clicked, this, &PresetFragment::onAddClicked);
@@ -58,7 +60,9 @@ void PresetFragment::onSelectionChanged(const QItemSelection &selected, const QI
 		return;
 	}
 
-    ui->presetName->setText(PresetManager::instance().presetModel()->data(selected.indexes().first(), Qt::UserRole).toString());
+    const QString selectedName = PresetManager::instance().presetModel()->data(selected.indexes().first(), Qt::UserRole).toString();
+    ui->presetName->setText(selectedName);
+    ui->rememberDevice->setChecked(PresetManager::instance().hasPresetDevice(selectedName));
 }
 
 void PresetFragment::onAddClicked()
@@ -68,8 +72,19 @@ void PresetFragment::onAddClicked()
         return;
     }
 
-    PresetManager::instance().save(ui->presetName->text());
-	ui->presetName->text() = "";
+    const QString name = ui->presetName->text();
+    PresetManager::instance().save(name);
+
+    if(ui->rememberDevice->isChecked())
+    {
+        PresetManager::instance().setPresetDevice(name);
+    }
+    else
+    {
+        PresetManager::instance().clearPresetDevice(name);
+    }
+
+    ui->presetName->clear();
 }
 
 void PresetFragment::onRemoveClicked()

--- a/src/interface/fragment/PresetFragment.ui
+++ b/src/interface/fragment/PresetFragment.ui
@@ -151,6 +151,7 @@
  <tabstops>
   <tabstop>presetName</tabstop>
   <tabstop>add</tabstop>
+  <tabstop>rememberDevice</tabstop>
   <tabstop>remove</tabstop>
   <tabstop>load</tabstop>
  </tabstops>

--- a/src/interface/fragment/PresetFragment.ui
+++ b/src/interface/fragment/PresetFragment.ui
@@ -70,6 +70,16 @@
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="rememberDevice">
+     <property name="toolTip">
+      <string>Save the current output device with this preset and switch to it when the preset is loaded</string>
+     </property>
+     <property name="text">
+      <string>Remember output device</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="CListView" name="files">
      <property name="contextMenuPolicy">
       <enum>Qt::CustomContextMenu</enum>


### PR DESCRIPTION
## What this does

Adds an opt-in **"Remember output device"** checkbox to the Presets panel. When checked at save time, the currently selected output device is stored alongside the preset. When that preset is later loaded — from the panel or the tray icon — the app automatically switches to that device, making profile switching a single action.

Default behaviour is completely unchanged: presets saved without the checkbox never affect the output device.

## Implementation details

**Storage** — a new `preset_devices.json` sidecar file managed by `PresetManager`, structured as a JSON object mapping preset name → `{deviceId, useDefault}`. This mirrors the existing `preset_rules.json` pattern and deliberately keeps device names out of the portable `.conf` preset files, since they are machine-specific.

**Apply path** — `applyPresetDevice()` sets `AppConfig::AudioOutputDevice` + `AppConfig::AudioOutputUseDefault`, which triggers a live device switch via `PipewireAudioService::onAppConfigUpdated` — the same path `SettingsFragment` uses when the user picks a device manually.

**Import safety** — the association is applied only when loading a *managed* preset from the presets directory. Files opened via *Load custom audio.conf* (`MainWindow::loadExternalFile()`, which also flows through `loadFromPath()`) never switch the device, even if the imported file's base name happens to collide with a saved preset.

**Feedback-loop guard** — the existing `onOutputDeviceChanged` rule system loads presets in response to device changes. A `_suppressDeviceApply` flag prevents the loaded preset from firing another device change in that code path.

**Rename/delete sync** — `PresetManager::rename()` and `remove()` keep `_presetDevices` in sync so stale entries don't accumulate.

**PulseAudio** — the new checkbox is hidden under `#ifdef USE_PULSEAUDIO` alongside the existing Rules button, since the PulseAudio device-switching path is stubbed (`PulsePipelineManager` hardcodes `use_default_sink = true`).

## Incidental fix

`PresetFragment::onAddClicked()` previously cleared the name field with `ui->presetName->text() = "";`. Because `QLineEdit::text()` returns a `QString` by value, this assigned to a throwaway temporary and the field was never actually cleared after saving. Replaced with `ui->presetName->clear()`.

## Files changed

- `src/data/PresetManager.h` — new map, path helper, load/save/set/clear/has/apply declarations
- `src/data/PresetManager.cpp` — full implementation + hooks in `loadFromPath` (scoped to managed presets), `rename`, `remove`, `onOutputDeviceChanged`
- `src/interface/fragment/PresetFragment.ui` — `rememberDevice` QCheckBox (added to tab order)
- `src/interface/fragment/PresetFragment.cpp` — checkbox wired to save/reflect state; hidden on PulseAudio; incidental `clear()` fix
